### PR TITLE
feat: implement player mode switching and improve comments section

### DIFF
--- a/src/youtube_colab_proxy/app/__init__.py
+++ b/src/youtube_colab_proxy/app/__init__.py
@@ -1,5 +1,6 @@
 import os
 from typing import Dict, Optional
+from urllib.parse import quote, urlparse
 
 import requests
 from flask import Flask, request, jsonify, Response, render_template
@@ -19,6 +20,30 @@ THUMB_HEADERS = {
 	"Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
 	"Referer": "https://www.youtube.com/",
 }
+
+
+def _to_proxy_image_url(raw_url: str) -> str:
+	if not raw_url:
+		return ""
+	try:
+		u = urlparse(raw_url)
+		if u.scheme not in ("http", "https"):
+			return ""
+		return f"/api/image-proxy?u={quote(raw_url, safe='')}"
+	except Exception:
+		return ""
+
+
+def _fetch_remote_image_bytes(img_url: str):
+	from .. import const as _const
+	s = requests.Session()
+	if _const.OUTBOUND_PROXY:
+		s.proxies.update({"http": _const.OUTBOUND_PROXY, "https": _const.OUTBOUND_PROXY})
+	r = s.get(img_url, timeout=12, headers=THUMB_HEADERS)
+	if r.status_code == 200 and r.content:
+		ctype = r.headers.get("Content-Type", "image/jpeg")
+		return r.content, ctype
+	return None, None
 
 
 def _pick_thumb_candidates(vid: str, pref: str = "hq"):
@@ -98,6 +123,25 @@ def create_app(cookie_file: Optional[str] = None) -> Flask:
 			return Response("Thumbnail not found", status=404)
 		resp = Response(data, status=200, mimetype=ctype or "image/jpeg")
 		resp.headers["Cache-Control"] = "public, max-age=3600"
+		return resp
+
+	@app.get("/api/image-proxy")
+	def api_image_proxy():  # type: ignore
+		raw = (request.args.get("u") or "").strip()
+		if not raw:
+			return Response("Missing image url", status=400)
+		try:
+			u = urlparse(raw)
+			if u.scheme not in ("http", "https"):
+				return Response("Invalid image url", status=400)
+		except Exception:
+			return Response("Invalid image url", status=400)
+
+		data, ctype = _fetch_remote_image_bytes(raw)
+		if not data:
+			return Response("Image not found", status=404)
+		resp = Response(data, status=200, mimetype=ctype or "image/jpeg")
+		resp.headers["Cache-Control"] = "public, max-age=1800"
 		return resp
 
 	@app.get("/api/search")
@@ -289,10 +333,11 @@ def create_app(cookie_file: Optional[str] = None) -> Flask:
 				text = str(text or "").strip()
 				if not cid or not text:
 					return None
+				raw_thumb = str(c.get("author_thumbnail") or "")
 				return {
 					"id": cid,
 					"author": str(c.get("author") or "Unknown"),
-					"author_thumbnail": str(c.get("author_thumbnail") or ""),
+					"author_thumbnail": _to_proxy_image_url(raw_thumb),
 					"text": text,
 					"like_count": int(c.get("like_count") or 0),
 					"timestamp": c.get("timestamp"),

--- a/src/youtube_colab_proxy/app/static/app.js
+++ b/src/youtube_colab_proxy/app/static/app.js
@@ -44,6 +44,8 @@ let currentListSource = null;
 let currentPlayingVideoId = null;
 let currentPlayingVideoUrl = null;
 let commentsReqToken = 0;
+let currentPlayerMode = 'normal';
+const PLAYER_MODE_KEY = 'ycp_player_mode_v1';
 
 // --- UI Helpers ---
 
@@ -73,6 +75,7 @@ const setStatus = (text) => {
 };
 
 const syncCommentsPanelHeight = () => {
+	if (currentPlayerMode === 'theater') return;
 	const panel = document.querySelector('#playerWrap .comments-panel');
 	const videoBox = document.querySelector('#playerWrap .watch-player-pane .aspect-video');
 	if (!(panel instanceof HTMLElement) || !(videoBox instanceof HTMLElement)) return;
@@ -85,6 +88,63 @@ const syncCommentsPanelHeight = () => {
 };
 
 window.addEventListener('resize', syncCommentsPanelHeight);
+
+const setPlayerModeUI = (mode) => {
+	$$('#playerModeSwitch .player-mode-btn').forEach((btn) => {
+		btn.classList.toggle('is-active', btn.getAttribute('data-mode') === mode);
+	});
+};
+
+const loadPlayerMode = () => {
+	try {
+		const raw = localStorage.getItem(PLAYER_MODE_KEY);
+		if (raw === 'theater' || raw === 'normal') return raw;
+	} catch {}
+	try {
+		const c = _getCookie(PLAYER_MODE_KEY);
+		if (c === 'theater' || c === 'normal') return c;
+	} catch {}
+	return 'normal';
+};
+
+const savePlayerMode = (mode) => {
+	if (mode !== 'theater' && mode !== 'normal') return;
+	try { localStorage.setItem(PLAYER_MODE_KEY, mode); } catch {}
+	_setCookie(PLAYER_MODE_KEY, mode, 365);
+};
+
+const applyTheaterCommentsCollapse = () => {
+	const body = document.body;
+	if (!body) return;
+	const app = loadAppSettings();
+	const collapsed = !!app.theaterCommentsCollapsed;
+	const inTheater = currentPlayerMode === 'theater';
+	body.classList.toggle('theater-comments-collapsed', inTheater && collapsed);
+	const btn = $('#theaterCommentsToggle');
+	if (btn instanceof HTMLButtonElement) {
+		btn.disabled = !inTheater;
+		btn.setAttribute('aria-disabled', !inTheater ? 'true' : 'false');
+		const pressed = inTheater && collapsed;
+		btn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+		btn.title = pressed ? 'Show comments in theater mode' : 'Collapse comments in theater mode';
+		const label = btn.querySelector('span');
+		if (label) label.textContent = pressed ? 'Show comments' : 'Hide comments';
+	}
+};
+
+const setPlayerMode = (mode) => {
+	const normalizedMode = mode === 'theater' ? 'theater' : 'normal';
+	const body = document.body;
+	if (!body) return;
+	body.classList.toggle('player-mode-theater', normalizedMode === 'theater');
+	currentPlayerMode = normalizedMode;
+	setPlayerModeUI(normalizedMode);
+	savePlayerMode(normalizedMode);
+	applyTheaterCommentsCollapse();
+	const panel = document.querySelector('#playerWrap .comments-panel');
+	if (panel instanceof HTMLElement) panel.style.height = '';
+	syncCommentsPanelHeight();
+};
 
 const escapeHtml = (s) => String(s || '')
 	.replace(/&/g, '&amp;')
@@ -178,6 +238,10 @@ const loadCommentsForCurrent = async () => {
 		return;
 	}
 	const sort = ($('#commentsSort')?.value || 'top');
+	const app = loadAppSettings();
+	const limitRaw = Number($('#commentsLimit')?.value || app.commentsLimit || 50);
+	const allowed = [10, 20, 50, 70, 100];
+	const limit = allowed.includes(limitRaw) ? limitRaw : 50;
 	const token = ++commentsReqToken;
 	clearCommentsList();
 	setCommentsState('Loading comments...');
@@ -185,7 +249,7 @@ const loadCommentsForCurrent = async () => {
 		const base = currentPlayingVideoId
 			? `/api/comments?id=${encodeURIComponent(currentPlayingVideoId)}`
 			: `/api/comments?url=${encodeURIComponent(currentPlayingVideoUrl)}`;
-		const url = `${base}&sort=${encodeURIComponent(sort)}&limit=80`;
+		const url = `${base}&sort=${encodeURIComponent(sort)}&limit=${limit}`;
 		const res = await fetch(url);
 		const data = await res.json();
 		if (token !== commentsReqToken) return;
@@ -201,6 +265,14 @@ const loadCommentsForCurrent = async () => {
 };
 
 $('#commentsSort')?.addEventListener('change', () => {
+	loadCommentsForCurrent();
+});
+
+$('#commentsLimit')?.addEventListener('change', () => {
+	const allowed = [10, 20, 50, 70, 100];
+	const raw = Number($('#commentsLimit')?.value || 50);
+	const commentsLimit = allowed.includes(raw) ? raw : 50;
+	saveAppSettings({ ...loadAppSettings(), commentsLimit });
 	loadCommentsForCurrent();
 });
 
@@ -457,7 +529,7 @@ const playById = (id, title, channel = '') => {
 // --- App Settings ---
 
 const APP_SETTINGS_KEY = 'ycp_app_settings_v3';
-const defaultAppSettings = { onEnd: 'stop', resolution: 0 };
+const defaultAppSettings = { onEnd: 'stop', resolution: 0, commentsLimit: 50, theaterCommentsCollapsed: false };
 const loadAppSettings = () => {
 	try {
 		const raw = localStorage.getItem(APP_SETTINGS_KEY);
@@ -1132,8 +1204,31 @@ $('#streamUrl')?.addEventListener('keydown', (e) => { if (e.key === 'Enter') pla
 // --- Init ---
 
 window.addEventListener('DOMContentLoaded', async () => {
+	$$('#playerModeSwitch .player-mode-btn').forEach((btn) => {
+		btn.addEventListener('click', () => {
+			const mode = btn.getAttribute('data-mode') || 'normal';
+			setPlayerMode(mode);
+		});
+	});
+	$('#theaterCommentsToggle')?.addEventListener('click', () => {
+		if (currentPlayerMode !== 'theater') return;
+		const app = loadAppSettings();
+		saveAppSettings({ ...app, theaterCommentsCollapsed: !app.theaterCommentsCollapsed });
+		applyTheaterCommentsCollapse();
+		syncCommentsPanelHeight();
+	});
+	setPlayerMode(loadPlayerMode());
+
 	setCommentsState('Play a YouTube video to load comments.');
 	setCommentsCount(-1);
+	const app = loadAppSettings();
+	const commentsLimitEl = $('#commentsLimit');
+	if (commentsLimitEl) {
+		const allowed = [10, 20, 50, 70, 100];
+		const limit = allowed.includes(Number(app.commentsLimit)) ? Number(app.commentsLimit) : 50;
+		commentsLimitEl.value = String(limit);
+	}
+	applyTheaterCommentsCollapse();
 	syncCommentsPanelHeight();
 
 	try {

--- a/src/youtube_colab_proxy/app/static/style.css
+++ b/src/youtube_colab_proxy/app/static/style.css
@@ -366,6 +366,72 @@ a {
 	outline: none;
 }
 
+.player-mode-switch {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px;
+	border-radius: 9999px;
+	background: rgba(255, 255, 255, 0.08);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.player-mode-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 30px;
+	padding: 0 10px;
+	border: 0;
+	border-radius: 9999px;
+	background: transparent;
+	color: #aaaaaa;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.player-mode-btn:hover {
+	background: rgba(255, 255, 255, 0.08);
+	color: #f1f1f1;
+}
+
+.player-mode-btn.is-active {
+	background: rgba(255, 255, 255, 0.2);
+	color: #f1f1f1;
+}
+
+.theater-comments-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 38px;
+	padding: 0 12px;
+	border: 0;
+	border-radius: 9999px;
+	background: #272727;
+	color: #f1f1f1;
+	font-size: 13px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.2s ease, opacity 0.2s ease;
+}
+
+.theater-comments-toggle:hover {
+	background: #303030;
+}
+
+.theater-comments-toggle[aria-pressed="true"] {
+	background: #3a3a3a;
+	color: #e5e5e5;
+}
+
+.theater-comments-toggle:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
 /* === Watch Layout (70/30 split) === */
 .watch-layout {
 	display: flex;
@@ -383,6 +449,32 @@ a {
 	flex: 0 0 30%;
 	max-width: 30%;
 	min-width: 280px;
+}
+
+body.player-mode-theater .watch-layout {
+	flex-direction: column;
+	gap: 14px;
+}
+
+body.player-mode-theater .watch-player-pane,
+body.player-mode-theater .watch-comments-pane {
+	flex: 1 1 auto;
+	max-width: 100%;
+	width: 100%;
+	min-width: 0;
+}
+
+body.player-mode-theater .comments-panel {
+	max-height: none;
+}
+
+body.player-mode-theater.theater-comments-collapsed .watch-comments-pane {
+	display: none;
+}
+
+body.player-mode-theater.theater-comments-collapsed .watch-player-pane {
+	max-width: 100%;
+	width: 100%;
 }
 
 .comments-panel {
@@ -424,8 +516,24 @@ a {
 	margin-top: 2px;
 }
 
+.comments-head-controls {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
 .comments-sort {
 	width: 130px;
+	height: 34px;
+	font-size: 13px;
+	padding-top: 0;
+	padding-bottom: 0;
+	border-radius: 9999px;
+	background-color: #272727;
+}
+
+.comments-limit {
+	width: 76px;
 	height: 34px;
 	font-size: 13px;
 	padding-top: 0;
@@ -587,6 +695,16 @@ a {
 
 	.comments-panel {
 		max-height: none;
+	}
+
+	.player-mode-switch {
+		width: 100%;
+		justify-content: space-between;
+	}
+
+	.player-mode-btn {
+		flex: 1 1 0;
+		justify-content: center;
 	}
 }
 

--- a/src/youtube_colab_proxy/app/templates/index.html
+++ b/src/youtube_colab_proxy/app/templates/index.html
@@ -112,6 +112,20 @@
 										</div>
 									</div>
 									<div class="flex items-center gap-2 flex-shrink-0">
+										<div id="playerModeSwitch" class="player-mode-switch" role="group" aria-label="Player view mode">
+											<button type="button" class="player-mode-btn is-active" data-mode="normal" title="Normal mode">
+												<i class="fa-solid fa-table-cells-large text-xs"></i>
+												<span>Normal</span>
+											</button>
+											<button type="button" class="player-mode-btn" data-mode="theater" title="Theater mode">
+												<i class="fa-solid fa-film text-xs"></i>
+												<span>Theater</span>
+											</button>
+										</div>
+										<button type="button" id="theaterCommentsToggle" class="theater-comments-toggle" title="Collapse comments in theater mode" aria-label="Collapse comments in theater mode" aria-pressed="false">
+											<i class="fa-solid fa-comments text-xs"></i>
+											<span>Comments</span>
+										</button>
 										<select id="videoResolution" class="hidden h-9 px-3 bg-yt-bg-secondary hover:bg-yt-bg-hover rounded-full text-sm text-yt-text border-none outline-none cursor-pointer transition-colors duration-200" title="Resolution"></select>
 										<a id="openStream" class="inline-flex items-center gap-2 h-9 px-4 bg-yt-bg-secondary hover:bg-yt-bg-hover rounded-full text-sm text-yt-text transition-colors duration-200" href="#" target="_blank" rel="noopener">
 											<i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
@@ -129,10 +143,19 @@
 										<h2 class="comments-panel-title">Comments</h2>
 										<div id="commentsCount" class="comments-panel-count"></div>
 									</div>
-									<select id="commentsSort" class="yt-select comments-sort" title="Comment sort">
-										<option value="top">Top</option>
-										<option value="new">Newest</option>
-									</select>
+									<div class="comments-head-controls">
+										<select id="commentsLimit" class="yt-select comments-limit" title="Comments to fetch">
+											<option value="10">10</option>
+											<option value="20">20</option>
+											<option value="50">50</option>
+											<option value="70">70</option>
+											<option value="100">100</option>
+										</select>
+										<select id="commentsSort" class="yt-select comments-sort" title="Comment sort">
+											<option value="top">Top</option>
+											<option value="new">Newest</option>
+										</select>
+									</div>
 								</div>
 								<div id="commentsState" class="comments-state">Play a YouTube video to load comments.</div>
 								<div id="commentsList" class="comments-list"></div>

--- a/src/youtube_colab_proxy/services/resolver.py
+++ b/src/youtube_colab_proxy/services/resolver.py
@@ -133,7 +133,7 @@ def fetch_youtube_comments(watch_url: str, max_comments: int = 80, comment_sort:
 	now = time.time()
 	cached = COMMENTS_CACHE.get(cache_key)
 	if cached and (now - float(cached.get("ts", 0))) < COMMENTS_CACHE_TTL_SEC:
-		return cached.get("comments", [])  # type: ignore[return-value]
+		return cached.get("comments", []) 
 
 	# yt-dlp may include comments in normal video extraction when it is quick.
 	# Reuse those if available to avoid a second extractor call.


### PR DESCRIPTION
- implement a toggle for switching between normal (player left, comments right) and theater mode
- added the ability to limit the number of comments displayed
- added a show/hide toggle for the comments section in theater mode to prevents the comments from obstructing the "Playing from search" section
- player mode, comment limits, and visibility settings are now persisted.
- comment author thumbnails now proxy-ed